### PR TITLE
Removed error when debugger is waiting for a set breakpoint to be found.

### DIFF
--- a/Libraries/Zilch/Debugging.cpp
+++ b/Libraries/Zilch/Debugging.cpp
@@ -492,8 +492,8 @@ void Debugger::OnOpcodePreStep(OpcodeEvent* e)
     }
   }
   break;
+  // Debugger is attached and looking for a breakpoint location
   case DebuggerAction::Resume:
-    Error("Invalid");
     break;
   }
 


### PR DESCRIPTION
Pretty sure the comment I added is the logic for this situation. Please double check.

That error is encountered when you click next to a line of code to set a breakpoint.